### PR TITLE
test: fix test name from 'title2' to 'title1'

### DIFF
--- a/apps/vite-plugin-use-electron-demo-e2e/src/example.spec.ts
+++ b/apps/vite-plugin-use-electron-demo-e2e/src/example.spec.ts
@@ -7,7 +7,7 @@ test('has title', async ({ page }) => {
   expect(await page.locator('h1').innerText()).toContain('Welcome');
 });
 
-test('has title2', async ({ page }) => {
+test('has title1', async ({ page }) => {
   await page.goto('/');
 
   // Expect h1 to contain a substring.

--- a/apps/vite-plugin-use-electron-demo-e2e/src/example.spec.ts
+++ b/apps/vite-plugin-use-electron-demo-e2e/src/example.spec.ts
@@ -6,3 +6,10 @@ test('has title', async ({ page }) => {
   // Expect h1 to contain a substring.
   expect(await page.locator('h1').innerText()).toContain('Welcome');
 });
+
+test('has title2', async ({ page }) => {
+  await page.goto('/');
+
+  // Expect h1 to contain a substring.
+  expect(await page.locator('h1').innerText()).toContain('Welcome');
+});


### PR DESCRIPTION
Corrected the test name in example.spec.ts to better reflect its purpose. Changed 'has title2' to 'has title1' for consistency with the first test case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify that the page displays a welcome message in the main heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->